### PR TITLE
Add PSF CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+PyBeach Code of Conduct
+
+The Python community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep Python a positive, successful, and growing community.
+
+A member of the Python community is:
+
+Open
+
+Members of the community are open to collaboration, whether it's on PEPs, patches, problems, or otherwise. We're receptive to constructive comment and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
+
+Considerate
+
+Members of the community are considerate of their peers -- other Python users. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labor was completed simply for the good of the community. We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
+
+Respectful
+
+Members of the community are respectful. We're respectful of others, their positions, their skills, their commitments, and their efforts. We're respectful of the volunteer efforts that permeate the Python community. We're respectful of the processes set forth in the community, and we work within them. When we disagree, we are courteous in raising our issues.
+
+Overall, we're good to each other. We contribute to this community not because we have to, but because we want to. If we remember that, these guidelines will come naturally.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,18 +1,18 @@
-PyBeach Code of Conduct
+# PyBeach Code of Conduct
 
 The Python community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences great successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines which help steer our interactions and strive to keep Python a positive, successful, and growing community.
 
 A member of the Python community is:
 
-Open
+## Open
 
 Members of the community are open to collaboration, whether it's on PEPs, patches, problems, or otherwise. We're receptive to constructive comment and criticism, as the experiences and skill sets of other members contribute to the whole of our efforts. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate and everyone can make a difference.
 
-Considerate
+## Considerate
 
 Members of the community are considerate of their peers -- other Python users. We're thoughtful when addressing the efforts of others, keeping in mind that often times the labor was completed simply for the good of the community. We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
 
-Respectful
+## Respectful
 
 Members of the community are respectful. We're respectful of others, their positions, their skills, their commitments, and their efforts. We're respectful of the volunteer efforts that permeate the Python community. We're respectful of the processes set forth in the community, and we work within them. When we disagree, we are courteous in raising our issues.
 

--- a/README.rst
+++ b/README.rst
@@ -56,3 +56,9 @@ Infrastructure
 --------------
 
 The site is deployed on `Netlify <https://www.netlify.com>`_ from the ``master`` branch of this repository, fully regenerated on every build. The domain is registered by `@nkantar <https://github.com/nkantar>`_ through `Hover <https://www.hover.com>`_, and SSL is provided by `Let's Encrypt <https://letsencrypt.org>`_.
+
+
+Code of Conduct
+---------------
+
+Everyone contributing to this repository is bound by the Code of Conduct employed by the conference. The full text can be found in the `CODE_OF_CONDUCT.md` file.

--- a/README.rst
+++ b/README.rst
@@ -61,4 +61,4 @@ The site is deployed on `Netlify <https://www.netlify.com>`_ from the ``master``
 Code of Conduct
 ---------------
 
-Everyone contributing to this repository is bound by the Code of Conduct employed by the conference. The full text can be found in the `CODE_OF_CONDUCT.md` file.
+Everyone contributing to this repository is bound by the Code of Conduct employed by the conference. The full text can be found in the ``CODE_OF_CONDUCT.md`` file.


### PR DESCRIPTION
I've added the [PSF CoC] in absence of having a favorite CoC of my own. If anyone has a preference, I'm more than happy to use that instead. I know the [Contributor Covenant] and [Citizen Code of Conduct] are somewhat popular options.

Alternately, we can modify the PSF one to suit our needs. One thing it lacks by default is information about how to report potential violations, for example.

We should also likely include that information on the site itself.

Consider this PR the start of that conversation.

[PSF CoC]: https://www.python.org/psf/codeofconduct/
[Contributor Covenant]: https://www.contributor-covenant.org'
[Citizen Code of Conduct]: http://citizencodeofconduct.org